### PR TITLE
Feat: add docs to menu

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -225,8 +225,13 @@ const Header: React.FC = () => {
           {/* FIXME remove this div if there is any item menu */}
           <div />
           <div className="flex items-center md:ml-12">
+            <Link href="https://docs.feature.sh">
+              <a className="ml-8 text-base font-medium text-neutral-200 hover:text-white">
+                Docs
+              </a>
+            </Link>
             <Link href="https://dashboard.feature.sh">
-              <a className="text-base font-medium text-neutral-200 hover:text-white">
+              <a className="ml-8 text-base font-medium text-neutral-200 hover:text-white">
                 {translate('navitem_dashboard')}
               </a>
             </Link>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -227,7 +227,7 @@ const Header: React.FC = () => {
           <div className="flex items-center md:ml-12">
             <Link href="https://docs.feature.sh">
               <a className="ml-8 text-base font-medium text-neutral-200 hover:text-white">
-                Docs
+                {translate('navitem_docs')}
               </a>
             </Link>
             <Link href="https://dashboard.feature.sh">

--- a/public/locales/en-US/header.json
+++ b/public/locales/en-US/header.json
@@ -2,6 +2,7 @@
 	"navitem_product": "Product",
 	"navitem_features": "Features",
 	"navitem_blog": "Blog",
+	"navitem_docs": "Docs",
 	"navitem_dashboard": "Dashboard",
 	"navitem_book": "Book a demo",
 	"navitem_pricing": "Pricing"

--- a/public/locales/fr/header.json
+++ b/public/locales/fr/header.json
@@ -2,6 +2,7 @@
 	"navitem_product": "Produit",
 	"navitem_features": "Fonctionnalités",
 	"navitem_blog": "Blog",
+	"navitem_docs": "Docs",
 	"navitem_dashboard": "Pannel",
 	"navitem_book": "Réserver une démo",
 	"navitem_pricing": "Prix"


### PR DESCRIPTION
- Added docs link to menu
- Added left margin to each link

As "Docs" has the same translation either in French and English (verified with ReactJS website), I didn't add it to header.json in locales. 

Should I add it to the locales even if it's the same word? Also, "blog" is in the same case.

@n1c01a5 @aurelien-brabant 