### PR TITLE
fix: add Github marketplace link in the mobile menu

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,21 +16,8 @@ import {
 } from '@heroicons/react/outline'
 import { BookOpenIcon } from '@heroicons/react/solid'
 
-const solutions = [
-  {
-    name: 'Product',
-    description:
-      'Get a better understanding of where your traffic is coming from.',
-    href: '/features',
-    icon: ViewGridIcon,
-  },
-  {
-    name: 'Docs',
-    description: 'Speak directly to your customers in a more meaningful way.',
-    href: 'https://docs.feature.sh',
-    icon: BookOpenIcon,
-  },
-]
+const NEXT_PUBLIC_DASHBOARD_URL_LINK = process.env.NEXT_PUBLIC_DASHBOARD_URL_LINK
+
 const resources = [
   {
     name: 'Help Center',
@@ -57,10 +44,24 @@ const resources = [
   },
 ]
 
-const NEXT_PUBLIC_DASHBOARD_URL_LINK = process.env.NEXT_PUBLIC_DASHBOARD_URL_LINK
-
 const Header: React.FC = () => {
   const { t: translate } = useTranslation('header')
+
+  const solutions = [
+    {
+      name: translate('navitem_product'),
+      description:
+        'Get a better understanding of where your traffic is coming from.',
+      href: '/features',
+      icon: ViewGridIcon,
+    },
+    {
+      name: translate('navitem_docs'),
+      description: 'Speak directly to your customers in a more meaningful way.',
+      href: 'https://docs.feature.sh',
+      icon: BookOpenIcon,
+    },
+  ]
 
   return (
     <Popover>
@@ -169,10 +170,16 @@ const Header: React.FC = () => {
                   {translate('navitem_book')}
                 </a>
                 <Link
+                  href="https://github.com/marketplace/feature-bot"
+                  className="block mt-5 text-center text-indigo-600 hover:text-indigo-500"
+                >
+                  {translate('navitem_sign_up')}
+                </Link>
+                <Link
                   href="https://dashboard.feature.sh"
                   className="block mt-5 text-center text-indigo-600 hover:text-indigo-500"
                 >
-                  Sign in
+                  {translate('navitem_dashboard')}
                 </Link>
               </div>
             </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,65 +3,17 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
 import { Popover, Transition } from '@headlessui/react'
-import {
-  ChartBarIcon,
-  ChatIcon,
-  CursorClickIcon,
-  DocumentReportIcon,
-  MenuIcon,
-  RefreshIcon,
-  ShieldCheckIcon,
-  ViewGridIcon,
-  XIcon,
-} from '@heroicons/react/outline'
+import { MenuIcon, XIcon } from '@heroicons/react/outline'
 import { BookOpenIcon } from '@heroicons/react/solid'
 
-const NEXT_PUBLIC_DASHBOARD_URL_LINK = process.env.NEXT_PUBLIC_DASHBOARD_URL_LINK
-
-const resources = [
-  {
-    name: 'Help Center',
-    description:
-      'Get all of your questions answered in our forums or contact support.',
-    href: '#',
-  },
-  {
-    name: 'Guides',
-    description:
-      'Learn how to maximize our platform to get the most out of it.',
-    href: '#',
-  },
-  {
-    name: 'Events',
-    description:
-      'See what meet-ups and other events we might be planning near you.',
-    href: '#',
-  },
-  {
-    name: 'Security',
-    description: 'Understand how we take your privacy seriously.',
-    href: '#',
-  },
-]
+const NEXT_PUBLIC_GITHUB_DOCS_LINK = process.env.NEXT_PUBLIC_GITHUB_DOCS_LINK
+const NEXT_PUBLIC_GITHUB_MARKETPLACE_LINK =
+  process.env.NEXT_PUBLIC_GITHUB_MARKETPLACE_LINK
+const NEXT_PUBLIC_DASHBOARD_URL_LINK =
+  process.env.NEXT_PUBLIC_DASHBOARD_URL_LINK
 
 const Header: React.FC = () => {
   const { t: translate } = useTranslation('header')
-
-  const solutions = [
-    {
-      name: translate('navitem_product'),
-      description:
-        'Get a better understanding of where your traffic is coming from.',
-      href: '/features',
-      icon: ViewGridIcon,
-    },
-    {
-      name: translate('navitem_docs'),
-      description: 'Speak directly to your customers in a more meaningful way.',
-      href: 'https://docs.feature.sh',
-      icon: BookOpenIcon,
-    },
-  ]
 
   return (
     <Popover>
@@ -73,15 +25,15 @@ const Header: React.FC = () => {
           </Link>
         </div>
         <div className="-my-2 -mr-2 md:hidden">
-          <Popover.Button className="inline-flex items-center justify-center p-2 text-gray-400 bg-black hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">
+          <Popover.Button className="inline-flex items-center justify-center bg-black p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">
             <span className="sr-only">Open menu</span>
-            <MenuIcon className="w-6 h-6" aria-hidden="true" />
+            <MenuIcon className="h-6 w-6" aria-hidden="true" />
           </Popover.Button>
         </div>
         <div className="hidden md:flex md:flex-1 md:items-center md:justify-between">
           <Popover.Group as="nav" className="flex space-x-10">
             <Link
-              href="https://docs.feature.sh"
+              href={NEXT_PUBLIC_GITHUB_DOCS_LINK || '#'}
               className="ml-8 text-base font-medium text-black hover:text-green-700"
             >
               {translate('navitem_docs')}
@@ -95,17 +47,11 @@ const Header: React.FC = () => {
               {translate('navitem_dashboard')}
             </Link>
             <Link
-              href="https://github.com/marketplace/feature-bot"
-              className="inline-flex items-center justify-center px-4 py-2 ml-8 text-base font-medium text-white bg-black border border-transparent shadow-sm hover:bg-green-700"
+              href={NEXT_PUBLIC_GITHUB_MARKETPLACE_LINK || '#'}
+              className="ml-8 inline-flex items-center justify-center border border-transparent bg-black px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-green-700"
             >
               {translate('navitem_sign_up')}
             </Link>
-            {/* <Link
-              href={process.env.NEXT_PUBLIC_CALENDAR_URL_BOOK_A_DEMO || '#'}
-              className="inline-flex items-center justify-center px-4 py-2 ml-8 text-base font-medium text-white bg-black border border-transparent shadow-sm hover:bg-green-700"
-            >
-              {translate('navitem_book')}
-            </Link> */}
           </div>
         </div>
       </div>
@@ -121,9 +67,9 @@ const Header: React.FC = () => {
       >
         <Popover.Panel
           focus
-          className="absolute inset-x-0 top-0 z-40 p-2 transition origin-top-right transform md:hidden"
+          className="absolute inset-x-0 top-0 z-40 origin-top-right transform p-2 transition md:hidden"
         >
-          <div className="bg-black divide-y-2 shadow-lg divide-gray-50 ring-1 ring-black ring-opacity-5">
+          <div className="divide-y-2 divide-gray-50 bg-black shadow-lg ring-1 ring-black ring-opacity-5">
             <div className="px-5 pt-5 pb-6">
               <div className="flex items-center justify-between">
                 <div>
@@ -135,52 +81,39 @@ const Header: React.FC = () => {
                   />
                 </div>
                 <div className="-mr-2">
-                  <Popover.Button className="inline-flex items-center justify-center p-2 text-gray-400 bg-white rounded-md hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">
+                  <Popover.Button className="inline-flex items-center justify-center rounded-md bg-white p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500">
                     <span className="sr-only">Close menu</span>
-                    <XIcon className="w-6 h-6" aria-hidden="true" />
+                    <XIcon className="h-6 w-6" aria-hidden="true" />
                   </Popover.Button>
                 </div>
               </div>
               <div className="mt-6">
-                <nav className="grid gap-6">
-                  {solutions.map((item) => (
-                    <Link
-                      key={item.name}
-                      href={item.href}
-                      className="flex items-center p-3 -m-3 text-white hover:bg-gray-50 hover:text-black"
-                      passHref={true}
-                    >
-                      <div className="flex items-center justify-center flex-shrink-0 w-10 h-10 text-white bg-indigo-500">
-                        <item.icon className="w-6 h-6" aria-hidden="true" />
-                      </div>
-                      <div className="ml-4 text-base font-medium">
-                        {item.name}
-                      </div>
-                    </Link>
-                  ))}
+                <nav className="grid justify-center gap-2">
+                  <Link
+                    href={NEXT_PUBLIC_GITHUB_DOCS_LINK || '#'}
+                    className="-m-3 flex items-center p-3 text-white hover:bg-gray-50 hover:text-black"
+                    passHref={true}
+                  >
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center bg-indigo-500 text-white">
+                      <BookOpenIcon className="h-6 w-6" aria-hidden="true" />
+                    </div>
+                    <div className="ml-4 text-base font-medium">
+                      {translate('navitem_docs')}
+                    </div>
+                  </Link>
+                  <Link
+                    href={NEXT_PUBLIC_GITHUB_MARKETPLACE_LINK || '#'}
+                    className="mt-5 block text-center text-indigo-600 hover:text-indigo-500"
+                  >
+                    {translate('navitem_sign_up')}
+                  </Link>
+                  <Link
+                    href={NEXT_PUBLIC_DASHBOARD_URL_LINK || '#'}
+                    className="mt-5 block text-center text-indigo-600 hover:text-indigo-500"
+                  >
+                    {translate('navitem_dashboard')}
+                  </Link>
                 </nav>
-              </div>
-            </div>
-            <div className="px-5 py-6">
-              <div>
-                <a
-                  href={process.env.NEXT_PUBLIC_CALENDAR_URL_BOOK_A_DEMO || '#'}
-                  className="flex items-center justify-center w-full px-4 py-2 text-base font-medium text-black bg-white border border-transparent shadow-sm hover:bg-yellow-500"
-                >
-                  {translate('navitem_book')}
-                </a>
-                <Link
-                  href="https://github.com/marketplace/feature-bot"
-                  className="block mt-5 text-center text-indigo-600 hover:text-indigo-500"
-                >
-                  {translate('navitem_sign_up')}
-                </Link>
-                <Link
-                  href="https://dashboard.feature.sh"
-                  className="block mt-5 text-center text-indigo-600 hover:text-indigo-500"
-                >
-                  {translate('navitem_dashboard')}
-                </Link>
               </div>
             </div>
           </div>

--- a/public/locales/fr/header.json
+++ b/public/locales/fr/header.json
@@ -4,7 +4,7 @@
 	"navitem_blog": "Blog",
 	"navitem_docs": "Docs ↗",
 	"navitem_dashboard": "Se Connecter",
-	"navitem_sign_up": "S'inscrire",
+	"navitem_sign_up": "S'Inscrire",
 	"navitem_book": "Réserver une Démo",
 	"navitem_pricing": "Prix"
 }


### PR DESCRIPTION
I added the link to Github Marketplace and completed the translations.
We have the three buttons of the desktop menu in that of the mobile menu, see the screenshoot:

<img width="382" alt="Capture d’écran 2023-08-29 à 17 41 59" src="https://github.com/feature-sh/website/assets/84193225/d067b048-326e-482e-b846-06a97ad45bf8">

